### PR TITLE
client: Ticker a rest ticker

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,10 +17,10 @@ package bitfinex_test
 import (
 	"log"
 
-	"github.com/orijtech/bitfinex"
+	"github.com/orijtech/bitfinex/v1"
 )
 
-func Example_client_Subscribe() {
+func Example_client_RealtimeTicker() {
 	client, err := bitfinex.NewClient()
 	if err != nil {
 		log.Fatal(err)
@@ -47,4 +47,16 @@ func Example_client_Subscribe() {
 	for ticker := range tkChan {
 		log.Printf("ticker: %+v\n", ticker)
 	}
+}
+
+func Example_client_Ticker() {
+	client, err := bitfinex.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+	tk, err := client.Ticker("BTC-USD")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("current ticker: %+v\n", tk)
 }


### PR DESCRIPTION
A method to return the ticker of a symbol at
the current time by invoking HTTP GET.

Sample usage
```go
package main

import (
	"log"

	"github.com/orijtech/bitfinex/v1"
)

func main() {
	client, err := bitfinex.NewClient()
	if err != nil {
		log.Fatal(err)
	}
	tk, err := client.Ticker("BTC-USD")
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("current ticker: %+v\n", tk)
}
```

which gives

```shell
2017/11/08 02:38:24 current ticker: &{TimeAt:2017-11-08 02:38:20.086462497 -0700 MST
Pair: ChannelID:0 Bid:7351.8 BidSize:0 Ask:7351.9 AskSize:0 DailyChange:0 LastPrice:7351.8
Volume:0 High:7420 Low:6948 Mid:7351.85 DailyChangePercentage:0 Err:<nil>}
```