### PR TITLE
balances method implemented, authenticated requests added

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -60,3 +60,17 @@ func Example_client_Ticker() {
 	}
 	log.Printf("current ticker: %+v\n", tk)
 }
+
+func Example_client_Balances() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	balances, err := client.Balances()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i, balance := range balances {
+		log.Printf("#%d: %+v\n", i, balance)
+	}
+}

--- a/v1/wallets.go
+++ b/v1/wallets.go
@@ -1,0 +1,51 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitfinex
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Balance struct {
+	Type      string  `json:"type,omitempty"`
+	Currency  string  `json:"currency,omitempty"`
+	Amount    float64 `json:"amount,string,omitempty"`
+	Available float64 `json:"available,string,omitempty"`
+}
+
+func (c *Client) Balances() ([]*Balance, error) {
+	fullURL := fmt.Sprintf("%s/balances", baseURL)
+	req, err := http.NewRequest("POST", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]interface{}{
+		"request": "/v1/balances",
+		"nonce":   fmt.Sprintf("%v", time.Now().Unix()*1e4),
+	}
+	blob, _, err := c.doAuthReq(req, payload)
+	if err != nil {
+		return nil, err
+	}
+	var balances []*Balance
+	if err := json.Unmarshal(blob, &balances); err != nil {
+		return nil, err
+	}
+	return balances, nil
+}


### PR DESCRIPTION
Fixes #5

* Implemented a method to retrieve balances
* A private method to authenticate requests

Exhibit:
```go
package main

import (
	"log"

	"github.com/orijtech/bitfinex/v1"
)

func main() {
	client, err := bitfinex.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}
	balances, err := client.Balances()
	if err != nil {
		log.Fatal(err)
	}
	for i, balance := range balances {
		log.Printf("#%d: %+v\n", i, balance)
	}
}
```

giving

```shell
2017/11/16 19:10:10 #0: &{Type:deposit Currency:eth Amount:0 Available:0}
2017/11/16 19:10:10 #1: &{Type:exchange Currency:eth Amount:950.41302623 Available:950.41302623}
2017/11/16 19:10:10 #2: &{Type:exchange Currency:ltc Amount:0 Available:0}

```