### PR TITLE
v1: implement Order, Buy, Sell APIs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -74,3 +74,50 @@ func Example_client_Balances() {
 		log.Printf("#%d: %+v\n", i, balance)
 	}
 }
+
+func Example_client_Buy() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Buy 3/4 BTC at $7500USD
+	res, err := client.Buy(0.75, "BTCUSD", 7500, bitfinex.Limit)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Response: %+v\n", res)
+}
+
+func Example_client_Sell() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Sell 107.3 ETH at $400USD
+	res, err := client.Buy(107.3, "ETHUSD", 7500, bitfinex.Limit)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Response: %+v\n", res)
+}
+
+func Example_client_Order() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Sell off all the LTC that we've got.
+	res, err := client.Order(&bitfinex.Order{
+		Side:            bitfinex.Sell,
+		Symbol:          "ETHBTC",
+		Price:           400,
+		Type:            bitfinex.FillOrKill,
+		UseAllAvailable: true,
+		Hidden:          true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Response: %+v\n", res)
+}

--- a/v1/order.go
+++ b/v1/order.go
@@ -1,0 +1,187 @@
+// Copyright 2017 orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitfinex
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/orijtech/otils"
+)
+
+type Order struct {
+	// Side is required, even in the zero value.
+	Side Side `json:"side,omitempty"`
+
+	Type Type `json:"type,omitempty"`
+
+	// Symbol is required, even in the zero value.
+	Symbol string `json:"symbol,omitempty"`
+
+	// Price is required, even in the zero value.
+	Price float64 `json:"price,string"`
+
+	// Amount is required, even in the zero value.
+	Amount float64 `json:"amount,string,omitempty"`
+
+	// Hidden if set, means that the order should be hidden.
+	Hidden bool `json:"is_hidden,omitempty"`
+
+	// PostOnly is only relevant for limit orders.
+	PostOnly bool `json:"is_postonly,omitempty"`
+
+	// UseAllAvailable if set will post an order
+	// that will use all of your available balance.
+	UseAllAvailable otils.NumericBool `json:"use_all_available,omitempty"`
+
+	// OCOOrder sets an additional STOP OCO order
+	// that will be linked with the current order.
+	// OCOOrder is optional but its serialized form
+	// must be sent even with the zero value.
+	OCOOrder bool `json:"ocoorder"`
+
+	// BuyPriceOCO represents the price of the OCO
+	// stop order to place iff OCOOrder is set.
+	// BuyPriceOCO is optional but its serialized form
+	// must be sent even with the zero value.
+	BuyPriceOCO float64 `json:"buy_price_oco"`
+
+	// SellPriceOCO represents the price of the OCO
+	// stop order to place if OCOOrder is set.
+	// SellPriceOCO is optional but its serialized form
+	// must be sent even with the zero value.
+	SellPriceOCO float64 `json:"sell_price_oco"`
+}
+
+type OrderResponse struct {
+	ID       uint64  `json:"id,omitempty"`
+	Symbol   string  `json:"symbol,omitempty"`
+	Exchange string  `json:"exchange,omitempty"`
+	Price    float64 `json:"price,string,omitempty"`
+
+	AverageExecutionPrice float64 `json:"avg_execution_price,string,omitempty"`
+
+	Side            Side    `json:"side,omitempty"`
+	Type            string  `json:"type,omitempty"`
+	TimestampMs     float64 `json:"timestamp,string,omitempty"`
+	IsLive          bool    `json:"is_live,omitempty"`
+	IsCancelled     bool    `json:"is_cancelled,omitempty"`
+	IsHidden        bool    `json:"is_hidden,omitempty"`
+	WasForced       bool    `json:"was_forced,omitempty"`
+	OriginalAmount  float64 `json:"original_amount,string,omitempty"`
+	RemainingAmount float64 `json:"remaining_amount,string,omitempty"`
+	ExecutedAmount  float64 `json:"executed_amount,string,omitempty"`
+	OrderID         uint64  `json:"order_id,omitempty"`
+}
+
+type Type string
+
+const (
+	ExchangeLimit        Type = "exchange limit"
+	ExchangeMarket       Type = "exchange market"
+	Market               Type = "market"
+	Limit                Type = "limit"
+	Stop                 Type = "stop"
+	TrailingStop         Type = "trailing-stop"
+	FillOrKill           Type = "fill-or-kill"
+	ExchangeTrailingStop Type = "exchange trailing-stop"
+	ExchangeFillOrKill   Type = "exchange fill-or-kill"
+)
+
+type Side string
+
+const (
+	Buy  Side = "buy"
+	Sell Side = "sell"
+)
+
+var (
+	errBlankOrderAmount = errors.New("expecting an order amount")
+	errBlankOrderType   = errors.New("expecting an order type")
+	errBlankOrderSide   = errors.New("expecting an order side")
+	errBlankOrderPrice  = errors.New("expecting an order price")
+)
+
+func (o *Order) Validate() error {
+	if o == nil || o.Type == "" {
+		return errBlankOrderType
+	}
+	if o.Side == "" {
+		return errBlankOrderSide
+	}
+	if o.Amount <= 0 {
+		return errBlankOrderAmount
+	}
+	if o.Price <= 0 {
+		return errBlankOrderPrice
+	}
+	return nil
+}
+
+func (c *Client) Order(order *Order) (*OrderResponse, error) {
+	if err := order.Validate(); err != nil {
+		return nil, err
+	}
+	blob, err := json.Marshal(order)
+	if err != nil {
+		return nil, err
+	}
+	payload := make(map[string]interface{})
+	if err := json.Unmarshal(blob, &payload); err != nil {
+		return nil, err
+	}
+
+	fullURL := fmt.Sprintf("%s/order/new", baseURL)
+	req, err := http.NewRequest("POST", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	payload["request"] = "/v1/order/new"
+	payload["nonce"] = fmt.Sprintf("%v", time.Now().Unix()*1e4)
+	payload["exchange"] = "bitfinex"
+	blob, _, err = c.doAuthReq(req, payload)
+	if err != nil {
+		return nil, err
+	}
+	resp := new(OrderResponse)
+	if err := json.Unmarshal(blob, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Sell is a convenience method to sell a currency instead of invoking Order.
+func (c *Client) Sell(amount float64, symbol string, price float64, typ Type) (*OrderResponse, error) {
+	return c.Order(&Order{
+		Side:   Sell,
+		Amount: amount,
+		Price:  price,
+		Type:   typ,
+	})
+}
+
+// Buy is a convenience method to buy a currency instead of invoking Order.
+func (c *Client) Buy(amount float64, symbol string, price float64, typ Type) (*OrderResponse, error) {
+	return c.Order(&Order{
+		Side:   Buy,
+		Amount: amount,
+		Price:  price,
+		Type:   typ,
+	})
+}

--- a/v1/orders_test.go
+++ b/v1/orders_test.go
@@ -1,0 +1,176 @@
+// Copyright 2017 orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bitfinex_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/orijtech/bitfinex/v1"
+)
+
+const (
+	orderRoute = "/order"
+
+	key1    = "^key1$"
+	key2    = "     k e72*"
+	secret1 = "***$3c5Et."
+	secret2 = "$3c***rEt2."
+)
+
+var blankOrderResponse = new(bitfinex.OrderResponse)
+
+func TestOrders(t *testing.T) {
+	tests := [...]struct {
+		key, secret string
+
+		order *bitfinex.Order
+		err   string
+	}{
+		0: {"", "", nil, "order type"},
+		1: {key1, secret1, nil, "order type"},
+		2: {
+			key1, secret1, &bitfinex.Order{
+				Type:   bitfinex.ExchangeMarket,
+				Side:   bitfinex.Sell,
+				Amount: 10,
+				Price:  20,
+			},
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		client := new(bitfinex.Client)
+		client.SetCredentials(&bitfinex.Credentials{Key: tt.key, Secret: tt.secret})
+		client.SetHTTPRoundTripper(&testRoundTripper{route: orderRoute})
+
+		res, err := client.Order(tt.order)
+		if tt.err != "" {
+			if err == nil {
+				t.Errorf("#%d: want non-nil error to contain %q", i, tt.err)
+			} else if g, w := err.Error(), tt.err; !strings.Contains(g, w) {
+				t.Errorf("#%d: got %q want %q", i, g, w)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("#%d: unexpected error: %v", i, err)
+			continue
+		}
+		if res == nil || reflect.DeepEqual(res, blankOrderResponse) {
+			t.Errorf("#%d:: want non-blank OrderResposne", i)
+		}
+	}
+}
+
+type testRoundTripper struct {
+	route string
+}
+
+var _ http.RoundTripper = (*testRoundTripper)(nil)
+
+func (tr *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch tr.route {
+	case orderRoute:
+		return tr.orderRoundTrip(req)
+	default:
+		return makeResp("Unimplemented", http.StatusBadRequest, nil), nil
+	}
+}
+
+func (tr *testRoundTripper) orderRoundTrip(req *http.Request) (*http.Response, error) {
+	blob, badRes, err := checkBadAuth(req, "POST")
+	if badRes != nil {
+		return badRes, nil
+	}
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	order := new(bitfinex.Order)
+	if err := json.Unmarshal(blob, order); err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	if err := order.Validate(); err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	return respFromFile("./testdata/new-order.json")
+}
+
+func checkBadAuth(req *http.Request, wantMethod string) ([]byte, *http.Response, error) {
+	if g, w := req.Method, wantMethod; g != w {
+		return nil, makeResp(fmt.Sprintf("got method %q want %q", g, w), http.StatusMethodNotAllowed, nil), nil
+	}
+	body, err := bodyAndAuthSignature(req)
+	return body, nil, err
+}
+
+var apiSecrets = map[string]string{
+	key1: secret1,
+	key2: secret2,
+}
+
+var errInvalidSignatures = errors.New("invalid/mismatched signatures")
+
+func bodyAndAuthSignature(req *http.Request) ([]byte, error) {
+	gotAPIKey := req.Header.Get("X-BFX-APIKEY")
+	secretKey, ok := apiSecrets[gotAPIKey]
+	if !ok {
+		return nil, errors.New("invalid/unknown API Key")
+	}
+	encodedPayload := req.Header.Get("X-BFX-PAYLOAD")
+	if encodedPayload == "" {
+		return nil, errors.New(`expected "X-BFX-PAYLOAD"`)
+	}
+	payload, err := base64.StdEncoding.DecodeString(encodedPayload)
+	if err != nil {
+		return nil, err
+	}
+	signature := req.Header.Get("X-BFX-SIGNATURE")
+
+	sig := hmac.New(sha512.New384, []byte(secretKey))
+	sig.Write([]byte(encodedPayload))
+	if g, w := fmt.Sprintf("%x", sig.Sum(nil)), signature; g != w {
+		return payload, errInvalidSignatures
+	}
+	return payload, nil
+}
+
+func respFromFile(p string) (*http.Response, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	return makeResp("200 OK", http.StatusOK, f), nil
+}
+
+func makeResp(status string, code int, r io.ReadCloser) *http.Response {
+	return &http.Response{
+		Header:     make(http.Header),
+		Body:       r,
+		Status:     status,
+		StatusCode: code,
+	}
+}

--- a/v1/testdata/new-order.json
+++ b/v1/testdata/new-order.json
@@ -1,0 +1,18 @@
+{
+  "id":448364249,
+  "symbol":"btcusd",
+  "exchange":"bitfinex",
+  "price":"0.01",
+  "avg_execution_price":"0.0",
+  "side":"buy",
+  "type":"exchange limit",
+  "timestamp":"1444272165.252370982",
+  "is_live":true,
+  "is_cancelled":false,
+  "is_hidden":false,
+  "was_forced":false,
+  "original_amount":"0.01",
+  "remaining_amount":"0.01",
+  "executed_amount":"0.0",
+  "order_id":448364249
+}


### PR DESCRIPTION
Fixes #4.

Implemented the:
* Order
* Buy
* Sell
APIs

samples
```go
func buy() {
	client, err := bitfinex.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}
	// Buy 3/4 BTC at $7500USD
	res, err := client.Buy(0.75, "BTCUSD", 7500, bitfinex.Limit)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("Response: %+v\n", res)
}

func sell() {
	client, err := bitfinex.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}
	// Sell 107.3 ETH at $400USD
	res, err := client.Buy(107.3, "ETHUSD", 7500, bitfinex.Limit)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("Response: %+v\n", res)
}

func order() {
	client, err := bitfinex.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	// Sell off all the LTC that we've got.
	res, err := client.Order(&bitfinex.Order{
		Side:            bitfinex.Sell,
		Symbol:          "ETHBTC",
		Price:           400,
		Type:            bitfinex.FillOrKill,
		UseAllAvailable: true,
		Hidden:          true,
	})
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("Response: %+v\n", res)
}
```