### PR TITLE
v1: Cancel + Status APIs implemented

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -121,3 +121,29 @@ func Example_client_Order() {
 	}
 	log.Printf("Response: %+v\n", res)
 }
+
+func Example_client_Status() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.Status(446915287)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Response: %+v\n", res)
+}
+
+func Example_client_Cancel() {
+	client, err := bitfinex.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := client.Cancel(446915287)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Response: %+v\n", res)
+}

--- a/v1/bitfinex.go
+++ b/v1/bitfinex.go
@@ -403,7 +403,7 @@ func (c *Client) apiSecret() string {
 	return secret
 }
 
-func (c *Client) doAuthReq(req *http.Request, payload map[string]interface{}) ([]byte, http.Header, error) {
+func (c *Client) doAuthReq(req *http.Request, payload interface{}) ([]byte, http.Header, error) {
 	blob, err := json.Marshal(payload)
 	if err != nil {
 		return nil, nil, err

--- a/v1/testdata/order-448364249.json
+++ b/v1/testdata/order-448364249.json
@@ -1,0 +1,18 @@
+{
+  "id":448364249,
+  "symbol":"btcusd",
+  "exchange":"bitfinex",
+  "price":"0.01",
+  "avg_execution_price":"0.0",
+  "side":"buy",
+  "type":"exchange limit",
+  "timestamp":"1444272165.252370982",
+  "is_live":true,
+  "is_cancelled":false,
+  "is_hidden":false,
+  "was_forced":false,
+  "original_amount":"0.01",
+  "remaining_amount":"0.01",
+  "executed_amount":"0.0",
+  "order_id":448364249
+}

--- a/v1/testdata/order-cancel-448364249.json
+++ b/v1/testdata/order-cancel-448364249.json
@@ -1,0 +1,18 @@
+{
+  "id":448364249,
+  "symbol":"btcusd",
+  "exchange":"bitfinex",
+  "price":"0.01",
+  "avg_execution_price":"0.0",
+  "side":"buy",
+  "type":"exchange limit",
+  "timestamp":"1444272165.252370982",
+  "is_live":true,
+  "is_cancelled":false,
+  "is_hidden":false,
+  "was_forced":false,
+  "original_amount":"0.01",
+  "remaining_amount":"0.01",
+  "executed_amount":"0.0",
+  "order_id":448364249
+}


### PR DESCRIPTION
Fixes https://github.com/orijtech/bitfinex/issues/8
Fixes https://github.com/orijtech/bitfinex/issues/9

Can now cancel as well as find out the status of orders.

Sample usage
```go
package main

import (
	"log"

	"github.com/orijtech/bitfinex/v1"
)

func main() {
	client, err := bitfinex.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	res, err := client.Status(446915287)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("Response: %+v\n", res)

	res, err := client.Cancel(446915287)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("Response: %+v\n", res)
}
```